### PR TITLE
Action V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,145 @@ The Codeball sub-actions are:
 ### Example: "Dry-run" mode, labels all PRs with the Codeball Result
 
 <details>
-  <summary>codeball.yml</summary>
+  <summary>examples/codeball-dry-run.yml</summary>
   
-  ## Heading
-  1. A numbered
-  2. list
-     * With some
-     * Sub bullets
+```
+on: [pull_request]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  codeball:
+    runs-on: ubuntu-latest
+    name: Codeball
+    steps:
+
+      # Start a new Codeball review job
+      # This step is asynchronous and will return a job id
+      - name: Trigger Codeball
+        id: codeball_baller
+        uses: sturdy-dev/codeball-action/baller@v2
+
+
+      # Wait for Codeball to return the status
+      - name: Get Status
+        id: codeball_status
+        uses: sturdy-dev/codeball-action/status@v2
+        with:
+          codeball-job-id: ${{ steps.codeball_baller.outputs.codeball-job-id }}
+
+      # If Codeball approved the contribution, add a "codeball:approved" label
+      - name: Label Approved
+        uses: sturdy-dev/codeball-action/labeler@v2
+        if: ${{ steps.codeball_status.outputs.approved == 'true' }}
+        with:
+          name: "codeball:approved"
+          color: "86efac" # green
+
+      # If Codeball did not approve the contribution, add a "codeball:needs-review" label
+      - name: Label Needs Review
+        uses: sturdy-dev/codeball-action/labeler@v2
+        if: ${{ steps.codeball_status.outputs.approved == 'false' }}
+        with:
+          name: "codeball:needs-review"
+          color: "bfdbfe" # blue
+
+```
+</details>
+
+### Example: Approve only (no labels)
+
+<details>
+  <summary>examples/codeball-approve.yml</summary>
+  
+```
+on: [pull_request]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  codeball:
+    runs-on: ubuntu-latest
+    name: Codeball
+    steps:
+
+      # Start a new Codeball review job
+      # This step is asynchronous and will return a job id
+      - name: Trigger Codeball
+        id: codeball_baller
+        uses: sturdy-dev/codeball-action/baller@v2
+
+
+      # Wait for Codeball to return the status
+      - name: Get Status
+        id: codeball_status
+        uses: sturdy-dev/codeball-action/status@v2
+        with:
+          codeball-job-id: ${{ steps.codeball_baller.outputs.codeball-job-id }}
+
+      # If Codeball approved the contribution, approve the PR
+      - name: Approve PR
+        uses: sturdy-dev/codeball-action/approver@v2
+        if: ${{ steps.codeball_status.outputs.approved == 'true' }}
+        with:
+          message: "Codeball: LGTM! :+1:"
+```
+</details>
+
+
+### Example: Filter files (run only for PRs modifying a single service)
+
+<details>
+  <summary>examples/codeball-filter-files.yml</summary>
+  
+```
+on:
+  pull_request:
+    # Run Codeball only if files under "/web/" has been modified (and no other files)
+    # See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths
+    paths:
+      - '!**'
+      - '/web/**'
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  codeball:
+    runs-on: ubuntu-latest
+    name: Codeball
+
+    steps:
+
+      # Start a new Codeball review job
+      # This step is asynchronous and will return a job id
+      - name: Trigger Codeball
+        id: codeball_baller
+        uses: sturdy-dev/codeball-action/baller@v2
+
+
+      # Wait for Codeball to return the status
+      - name: Get Status
+        id: codeball_status
+        uses: sturdy-dev/codeball-action/status@v2
+        with:
+          codeball-job-id: ${{ steps.codeball_baller.outputs.codeball-job-id }}
+
+      # If Codeball approved the contribution, approve the PR
+      - name: Approve PR
+        uses: sturdy-dev/codeball-action/approver@v2
+        if: ${{ steps.codeball_status.outputs.approved == 'true' }}
+        with:
+          message: "Codeball: LGTM! :+1:"
+```
 </details>
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
     name: Run Codeball
     steps:
       - name: Codeball AI Actions
-        uses: sturdy-dev/codeball-action@v1
+        uses: sturdy-dev/codeball-action@v2
         # with:
         #   do-label: "true"                    # Configure if the action should label approved contributions
         #   label-name: "codeball:approved"     # Configure the label name to set if Codeball approves the contribution
@@ -31,6 +31,29 @@ jobs:
 ```
 
 2. 🎉 That's it! Codeball will now run on your pull requests, and will pre-approve your PR if it's a good one!
+
+## Customizations
+
+Codeball Actions are built on multiple smaller building-blocks, that are heavily configurable through GitHub Actions.
+
+The Codeball sub-actions are:
+
+* Baller – Triggers new Codeball Jobs
+* Status – Waits for the the Codeball result
+* Approver – Approves PRs
+* Labeler – Adds labels to PRs
+
+### Example: "Dry-run" mode, labels all PRs with the Codeball Result
+
+<details>
+  <summary>codeball.yml</summary>
+  
+  ## Heading
+  1. A numbered
+  2. list
+     * With some
+     * Sub bullets
+</details>
 
 ## Troubleshooting
 

--- a/action.yml
+++ b/action.yml
@@ -1,42 +1,38 @@
 # See https://github.com/sturdy-dev/codeball-action for more information of how to use this action
 name: Codeball AI Actions
-description: AI Code Review
+description: AI Code Review – Codeball approves Pull Requests that a human would have approved. Wait less for review, save time and $$$.
 
 author: Sturdy
 branding:
   icon: check
   color: orange
 
-inputs:
-  do-label:
-    description: 'If "true", the action will label Pull Request if Codeball AI approves the contribution'
-    default: "true"
-    required: false
-  label-name:
-    description: 'Label value to be set.'
-    default: 'codeball:approved'
-    required: false
-  do-approve:
-    description: 'If "true", the action will submit an approving Pull Request review if Codeball AI approves the contribution'
-    default: "true"
-    required: false
-
 runs:
   using: 'composite'
   steps:
+
     # Start a new Codeball review job
     # This step is asynchronous and will return a job id
     - name: Trigger Codeball
       id: codeball_baller
-      uses: sturdy-dev/codeball-action/baller@v1
+      uses: sturdy-dev/codeball-action/baller@v2
 
-    # Wait for the codeball_baller job to complete
-    # Approves the Pull Request if Codeball approves it
-    - name: Codeball Approver
-      id: codeball_approver
-      uses: sturdy-dev/codeball-action/approver@v1
+    # Wait for Codeball to return the status
+    - name: Get Status
+      id: codeball_status
+      uses: sturdy-dev/codeball-action/status@v2
       with:
         codeball-job-id: ${{ steps.codeball_baller.outputs.codeball-job-id }}
-        do-label: ${{ inputs.do-label }}
-        label-name: ${{ inputs.label-name }}
-        do-approve: ${{ inputs.do-approve }}
+
+    # If Codeball approved the contribution, add a "codeball:approved" label
+    - name: Label Approved
+      uses: sturdy-dev/codeball-action/labeler@v2
+      if: ${{ steps.codeball_status.outputs.approved == 'true' }}
+      with:
+        name: "codeball:approved"
+        color: "86efac" # green
+
+    # If Codeball approved the contribution, approve the PR
+    - name: Approve PR
+      uses: sturdy-dev/codeball-action/approver@v2
+      if: ${{ steps.codeball_status.outputs.approved == 'true' }}

--- a/examples/codeball-approve.yaml
+++ b/examples/codeball-approve.yaml
@@ -1,0 +1,33 @@
+on: [pull_request]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  codeball:
+    runs-on: ubuntu-latest
+    name: Codeball
+    steps:
+
+      # Start a new Codeball review job
+      # This step is asynchronous and will return a job id
+      - name: Trigger Codeball
+        id: codeball_baller
+        uses: sturdy-dev/codeball-action/baller@v2
+
+
+      # Wait for Codeball to return the status
+      - name: Get Status
+        id: codeball_status
+        uses: sturdy-dev/codeball-action/status@v2
+        with:
+          codeball-job-id: ${{ steps.codeball_baller.outputs.codeball-job-id }}
+
+      # If Codeball approved the contribution, approve the PR
+      - name: Approve PR
+        uses: sturdy-dev/codeball-action/approver@v2
+        if: ${{ steps.codeball_status.outputs.approved == 'true' }}
+        with:
+          message: "Codeball: LGTM! :+1:"

--- a/examples/codeball-dry-run.yaml
+++ b/examples/codeball-dry-run.yaml
@@ -1,0 +1,42 @@
+on: [pull_request]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  codeball:
+    runs-on: ubuntu-latest
+    name: Codeball
+    steps:
+
+      # Start a new Codeball review job
+      # This step is asynchronous and will return a job id
+      - name: Trigger Codeball
+        id: codeball_baller
+        uses: sturdy-dev/codeball-action/baller@v2
+
+
+      # Wait for Codeball to return the status
+      - name: Get Status
+        id: codeball_status
+        uses: sturdy-dev/codeball-action/status@v2
+        with:
+          codeball-job-id: ${{ steps.codeball_baller.outputs.codeball-job-id }}
+
+      # If Codeball approved the contribution, add a "codeball:approved" label
+      - name: Label Approved
+        uses: sturdy-dev/codeball-action/labeler@v2
+        if: ${{ steps.codeball_status.outputs.approved == 'true' }}
+        with:
+          name: "codeball:approved"
+          color: "86efac" # green
+
+      # If Codeball did not approve the contribution, add a "codeball:needs-review" label
+      - name: Label Needs Review
+        uses: sturdy-dev/codeball-action/labeler@v2
+        if: ${{ steps.codeball_status.outputs.approved == 'false' }}
+        with:
+          name: "codeball:needs-review"
+          color: "bfdbfe" # blue

--- a/examples/codeball-filter-files.yaml
+++ b/examples/codeball-filter-files.yaml
@@ -1,0 +1,40 @@
+on:
+  pull_request:
+    # Run Codeball only if files under "/web/" has been modified (and no other files)
+    # See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths
+    paths:
+      - '!**'
+      - '/web/**'
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  codeball:
+    runs-on: ubuntu-latest
+    name: Codeball
+
+    steps:
+
+      # Start a new Codeball review job
+      # This step is asynchronous and will return a job id
+      - name: Trigger Codeball
+        id: codeball_baller
+        uses: sturdy-dev/codeball-action/baller@v2
+
+
+      # Wait for Codeball to return the status
+      - name: Get Status
+        id: codeball_status
+        uses: sturdy-dev/codeball-action/status@v2
+        with:
+          codeball-job-id: ${{ steps.codeball_baller.outputs.codeball-job-id }}
+
+      # If Codeball approved the contribution, approve the PR
+      - name: Approve PR
+        uses: sturdy-dev/codeball-action/approver@v2
+        if: ${{ steps.codeball_status.outputs.approved == 'true' }}
+        with:
+          message: "Codeball: LGTM! :+1:"

--- a/hack/build-v2.sh
+++ b/hack/build-v2.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+git stash
+git checkout v2
+git merge main --no-edit
+
+# Build
+yarn build
+yarn package
+git add lib dist || true
+git commit -m "Build action" --allow-empty
+
+# Push
+git push -u origin v2:v2


### PR DESCRIPTION
We're currently working on a more flexible version of the Codeball Action for GitHub Actions.

The big change is that the "approver" action has been split into multiple smaller ones (status, labeler, approver).

The `v2` branch is currently a work-in-progress, and is not yet stable.